### PR TITLE
Updated POM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,5 @@
 /project/nbproject
 /project/catalog.xml
 /project/.Build.scala.swp
+.project
+.settings

--- a/mybatis-scala-core/pom.xml
+++ b/mybatis-scala-core/pom.xml
@@ -14,7 +14,8 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -25,18 +26,18 @@
 
   <artifactId>mybatis-scala-core_2.10</artifactId>
   <packaging>jar</packaging>
-  <name>MyBatis Scala API Core</name>
+  <name>mybatis-scala-core</name>
 
   <properties>
     <scala.binary>2.10</scala.binary>
-    <scala.version>${scala.binary}.3</scala.version>
+    <scala.version>${scala.binary}.4</scala.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>org.mybatis</groupId>
       <artifactId>mybatis</artifactId>
-      <version>3.2.4</version>
+      <version>3.2.7</version>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>
@@ -46,7 +47,7 @@
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary}</artifactId>
-      <version>2.1.7</version>
+      <version>2.2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -66,7 +67,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.0</version>
         <configuration>
           <reportPlugins>
             <plugin>
@@ -77,7 +77,7 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-changes-plugin</artifactId>
-              <version>2.7.1</version>
+              <version>2.10</version>
               <reportSets>
                 <reportSet>
                   <reports>
@@ -92,7 +92,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.7</version>
+        <version>2.17</version>
         <configuration>
             <skipTests>true</skipTests>
         </configuration>
@@ -100,7 +100,7 @@
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
-        <version>1.0-RC2</version>
+        <version>1.0</version>
         <configuration>
           <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
           <junitxml>.</junitxml>
@@ -119,7 +119,7 @@
 
     <resources>
       <resource>
-        <directory>${basedir}/../</directory>
+        <directory>${project.basedir}/../</directory>
         <targetPath>META-INF</targetPath>
         <includes>
           <include>LICENSE</include>

--- a/mybatis-scala-samples/pom.xml
+++ b/mybatis-scala-samples/pom.xml
@@ -14,7 +14,8 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -25,11 +26,11 @@
 
   <artifactId>mybatis-scala-samples_2.10</artifactId>
   <packaging>jar</packaging>
-  <name>MyBatis Scala API Samples</name>
+  <name>mybatis-scala-samples</name>
 
   <properties>
     <scala.binary>2.10</scala.binary>
-    <scala.version>${scala.binary}.3</scala.version>
+    <scala.version>${scala.binary}.4</scala.version>
   </properties>
 
   <dependencies>
@@ -46,7 +47,7 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.2.8</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 
@@ -67,10 +68,10 @@
 
     <resources>
       <resource>
-        <directory>${basedir}/src/main/resources</directory>
+        <directory>${project.basedir}/src/main/resources</directory>
       </resource>
       <resource>
-        <directory>${basedir}/../</directory>
+        <directory>${project.basedir}/../</directory>
         <targetPath>META-INF</targetPath>
         <includes>
           <include>LICENSE</include>

--- a/pom.xml
+++ b/pom.xml
@@ -14,13 +14,14 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.mybatis</groupId>
     <artifactId>mybatis-parent</artifactId>
-    <version>20</version>
+    <version>22-SNAPSHOT</version>
   </parent>
 
   <groupId>org.mybatis.scala</groupId>
@@ -28,7 +29,7 @@
   <version>1.0.3-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <name>MyBatis Scala</name>
+  <name>mybatis-scala-parent</name>
   <url>http://www.mybatis.org/scala</url>
 
   <modules>
@@ -59,8 +60,8 @@
 
   <properties>
     <findbugs.onlyAnalyze>org.mybatis.scala.*</findbugs.onlyAnalyze>
-    <javac.src.version>1.6</javac.src.version>
-    <javac.target.version>1.6</javac.target.version>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
     <gcu.product>Scala</gcu.product>
   </properties>
 
@@ -102,6 +103,32 @@
               <phase>test-compile</phase>
             </execution>
           </executions>
+        </plugin>
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        <plugin>
+            <groupId>org.eclipse.m2e</groupId>
+            <artifactId>lifecycle-mapping</artifactId>
+            <version>1.0.0</version>
+            <configuration>
+                <lifecycleMappingMetadata>
+                    <pluginExecutions>
+                        <pluginExecution>
+                            <pluginExecutionFilter>
+                                <groupId>org.scala-tools</groupId>
+                                <artifactId>maven-scala-plugin</artifactId>
+                                <versionRange>[2.15.2,)</versionRange>
+                                <goals>
+                                    <goal>testCompile</goal>
+                                    <goal>compile</goal>
+                                </goals>
+                            </pluginExecutionFilter>
+                            <action>
+                                <ignore></ignore>
+                            </action>
+                        </pluginExecution>
+                    </pluginExecutions>
+                </lifecycleMappingMetadata>
+            </configuration>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Modified <name> to allow proper import into myEclipse and following
maven suggestions that name match <artifact>.  In this case, did not add
version number to name.

Use mybatis-parent 22-SNAPSHOT
Use standard maven defaults for compiler version
Fix xsd location for maven
Use 'project.basedir' rather than 'basedir' as the later is deprecated
Updated scala to 2.10.4 -> Update to 2.11 will require some changes...
Updated hsqldb to 2.3.2
Updated maven-changes-plugin to 2.10
Updated surefire plugin to 2.17 (unsure why it is not seeing parent
version in this case!)
Updated scalatest-maven-plugin to 1.0
Updated scalatest to 2.2.0
Updated mybatis to 3.2.7
