### PR TITLE
get things compiling against MB3.3.0 .

### DIFF
--- a/mybatis-scala-core/src/main/scala/org/mybatis/scala/config/Configuration.scala
+++ b/mybatis-scala-core/src/main/scala/org/mybatis/scala/config/Configuration.scala
@@ -85,8 +85,9 @@ sealed class Configuration(private val configuration: MBConfig) {
     flushInterval: Long = -1,
     size: Int = -1,
     readWrite: Boolean = true,
+    blocking : Boolean = false,
     props: Properties = null) =
-    defaultSpace.cache(impl, eviction, flushInterval, size, readWrite, props)
+    defaultSpace.cache(impl, eviction, flushInterval, size, readWrite, blocking, props)
 
   /** Reference to an external Cache */
   def cacheRef(that: ConfigurationSpace) = defaultSpace.cacheRef(that)
@@ -350,8 +351,9 @@ object Configuration {
       flushInterval: Long = -1,
       size: Int = -1,
       readWrite: Boolean = true,
+      blocking : Boolean = false,
       props: Properties = null) = 
-        set(2, pos) { _.cache(impl, eviction, flushInterval, size, readWrite, props) }
+        set(2, pos) { _.cache(impl, eviction, flushInterval, size, readWrite, blocking, props) }
 
     // PENDING FOR mybatis 3.1.1+ ==================================================
     

--- a/mybatis-scala-core/src/main/scala/org/mybatis/scala/config/ConfigurationSpace.scala
+++ b/mybatis-scala-core/src/main/scala/org/mybatis/scala/config/ConfigurationSpace.scala
@@ -74,6 +74,7 @@ class ConfigurationSpace(configuration : MBConfig, val spaceName : String = "_DE
     flushInterval : Long = -1,
     size : Int = -1,
     readWrite : Boolean = true,
+    blocking : Boolean = false,
     props : Properties = null) : this.type = {
 
     builderAssistant.useNewCache(
@@ -82,6 +83,7 @@ class ConfigurationSpace(configuration : MBConfig, val spaceName : String = "_DE
       if (flushInterval > -1) flushInterval else null,
       if (size > -1) size else null,
       readWrite,
+      blocking,
       props
     )
     this

--- a/mybatis-scala-core/src/main/scala/org/mybatis/scala/mapping/Select.scala
+++ b/mybatis-scala-core/src/main/scala/org/mybatis/scala/mapping/Select.scala
@@ -80,8 +80,8 @@ abstract class SelectList[Result : Manifest]
   def apply()(implicit s : Session) : Seq[Result] = 
     execute { s.selectList[Result](fqi.id) }
 
-  def handle(callback : ResultContext => Unit)(implicit s : Session) : Unit =
-    execute { s.select(fqi.id, new ResultHandlerDelegator(callback)) }
+  def handle[T](callback : ResultContext[_ <: T] => Unit)(implicit s : Session) : Unit =
+    execute { s.select(fqi.id, new ResultHandlerDelegator[T](callback)) }
 
 }
 
@@ -118,8 +118,8 @@ abstract class SelectListBy[Param : Manifest, Result : Manifest]
   def apply(param : Param)(implicit s : Session) : Seq[Result] = 
     execute { s.selectList[Param,Result](fqi.id, param) }
 
-  def handle(param : Param, callback : ResultContext => Unit)(implicit s : Session) : Unit = 
-    execute { s.select(fqi.id, param, new ResultHandlerDelegator(callback)) }
+  def handle(param : Param, callback : ResultContext[_ <: Result] => Unit)(implicit s : Session) : Unit =
+    execute { s.select(fqi.id, param, new ResultHandlerDelegator[Result](callback)) }
 
 }
 
@@ -155,8 +155,8 @@ abstract class SelectListPage[Result : Manifest]
   def apply(rowBounds : RowBounds)(implicit s : Session) : Seq[Result] = 
     execute { s.selectList[Null,Result](fqi.id, null, rowBounds) }
 
-  def handle(rowBounds : RowBounds, callback : ResultContext => Unit)(implicit s : Session) : Unit =
-    execute { s.select(fqi.id, rowBounds, new ResultHandlerDelegator(callback)) }
+  def handle(rowBounds : RowBounds, callback : ResultContext[_ <: Seq[Result]] => Unit)(implicit s : Session) : Unit =
+    execute { s.select(fqi.id, rowBounds, new ResultHandlerDelegator[Seq[Result]](callback)) }
 
 }
 
@@ -193,8 +193,8 @@ abstract class SelectListPageBy[Param : Manifest, Result : Manifest]
   def apply(param : Param, rowBounds : RowBounds)(implicit s : Session) : Seq[Result] = 
     execute { s.selectList[Param,Result](fqi.id, param, rowBounds) }
 
-  def handle(param : Param, rowBounds : RowBounds, callback : ResultContext => Unit)(implicit s : Session) : Unit =
-    execute { s.select(fqi.id, param, rowBounds, new ResultHandlerDelegator(callback)) }
+  def handle(param : Param, rowBounds : RowBounds, callback : ResultContext[_ <: Seq[Result]] => Unit)(implicit s : Session) : Unit =
+    execute { s.select(fqi.id, param, rowBounds, new ResultHandlerDelegator[Seq[Result]](callback)) }
 
 }
 

--- a/mybatis-scala-core/src/main/scala/org/mybatis/scala/session/ResultHandlerDelegator.scala
+++ b/mybatis-scala-core/src/main/scala/org/mybatis/scala/session/ResultHandlerDelegator.scala
@@ -16,6 +16,6 @@
 
 package org.mybatis.scala.session
 
-class ResultHandlerDelegator(callback : ResultContext => Unit) extends ResultHandler {
-  def handleResult(context : ResultContext) : Unit = callback(context)
+class ResultHandlerDelegator[T](callback : ResultContext[_ <: T] => Unit) extends ResultHandler[T] {
+  def handleResult(context : ResultContext[_ <: T]) : Unit = callback(context)
 }

--- a/mybatis-scala-core/src/main/scala/org/mybatis/scala/session/Session.scala
+++ b/mybatis-scala-core/src/main/scala/org/mybatis/scala/session/Session.scala
@@ -65,15 +65,15 @@ class Session(sqls : SqlSession) {
     mapAsScalaMap(sqls.selectMap[Key,Value](statement, parameter, mapKey, rowBounds.unwrap))
   }
 
-  def select[Param](statement : String, parameter : Param, handler : ResultHandler) : Unit = {
+  def select[Param, Res](statement : String, parameter : Param, handler : ResultHandler[Res]) : Unit = {
     sqls.select(statement, parameter, handler)
   }
 
-  def select(statement : String, handler : ResultHandler) : Unit = {
+  def select[T](statement : String, handler : ResultHandler[T]) : Unit = {
     sqls.select(statement, handler)
   }
 
-  def select[Param](statement : String, parameter : Param, rowBounds : RowBounds, handler : ResultHandler) : Unit = {
+  def select[Param, Res](statement : String, parameter : Param, rowBounds : RowBounds, handler : ResultHandler[Res]) : Unit = {
     sqls.select(statement, parameter, rowBounds.unwrap, handler)
   }
 

--- a/mybatis-scala-core/src/main/scala/org/mybatis/scala/session/package.scala
+++ b/mybatis-scala-core/src/main/scala/org/mybatis/scala/session/package.scala
@@ -39,10 +39,10 @@ import org.apache.ibatis.session.{RowBounds => MBRowBounds}
 package object session {
 
   /** Alias of [[org.apache.ibatis.session.ResultHandler]] */
-  type ResultHandler = MBResultHandler
+  type ResultHandler[T] = MBResultHandler[T]
   
   /** Alias of [[org.apache.ibatis.session.ResultContext]] */
-  type ResultContext = MBResultContext
+  type ResultContext[T] = MBResultContext[T]
   
   /** Alias of [[org.apache.ibatis.executor.BatchResult]] */
   type BatchResult = org.apache.ibatis.executor.BatchResult


### PR DESCRIPTION
fixes #23 
basically, add the boolean 'blocking' parameter to cache related configurations (default is false as it seems to match MB's internals).
few additional changes dut to MB interfaces that became generics (see org.mybatis.scala.session for details, i.e. ResultHandler and ResultContext).